### PR TITLE
Add MeCab support files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update && \
     libexpat1-dev \
     libevent-dev \
     libmecab-dev \
+    mecab \
     cmake
 
 # Build


### PR DESCRIPTION
This is segfaulting because libmecab can't build a tagger without support files.

This doesn't make it _work_, but it stops the segfaults. It now shows an encoding error.